### PR TITLE
Date et heure prises en compte comme dans le PDF

### DIFF
--- a/AttestationCovid/Form/FormViewController.swift
+++ b/AttestationCovid/Form/FormViewController.swift
@@ -178,13 +178,19 @@ final class FormViewController: UITableViewController {
         case (.date, FormSection.DateContent.date.rawValue):
             let cell = self.keyValueCell(tableView, indexPath: indexPath)
             cell.configure(name: NSLocalizedString("date", comment: ""), value: DateFormatter.date.string(from: attestation.date), inputType: .date(DateFormatter.date)) { [weak self] value in
-//                self?.attestation.date
+                let actualDate = self?.attestation.date ?? Date()
+                let newDateString = value + " " + DateFormatter.hour.string(from: actualDate) +  ":" + DateFormatter.minute.string(from: actualDate)
+                let newDate = DateFormatter.dateTimeFr.date(from: newDateString) ?? Date()
+                self?.attestation.date = newDate
+                print("Updated date: " + value + " | attestation date: " + DateFormatter.dateTimeFr.string(from: self?.attestation.date ?? Date() ))
             }
             return cell
         case (.date, FormSection.DateContent.time.rawValue):
             let cell = self.keyValueCell(tableView, indexPath: indexPath)
             cell.configure(name: NSLocalizedString("time", comment: ""), value: DateFormatter.time.string(from: attestation.date), inputType: .time(DateFormatter.time)) { [weak self] value in
-                //                self?.attestation.date
+                let actualDate = DateFormatter.dateFr.string(from: self?.attestation.date ?? Date())
+                self?.attestation.date = DateFormatter.dateTimeFr.date(from: actualDate + " " + value) ?? Date()
+                print("Updated time: " + value + " | attestation date: " + DateFormatter.dateTimeFr.string(from: self?.attestation.date ?? Date() ))
             }
             return cell
 

--- a/AttestationCovid/Form/FormViewController.swift
+++ b/AttestationCovid/Form/FormViewController.swift
@@ -182,7 +182,6 @@ final class FormViewController: UITableViewController {
                 let newDateString = value + " " + DateFormatter.hour.string(from: actualDate) +  ":" + DateFormatter.minute.string(from: actualDate)
                 let newDate = DateFormatter.dateTimeFr.date(from: newDateString) ?? Date()
                 self?.attestation.date = newDate
-                print("Updated date: " + value + " | attestation date: " + DateFormatter.dateTimeFr.string(from: self?.attestation.date ?? Date() ))
             }
             return cell
         case (.date, FormSection.DateContent.time.rawValue):
@@ -190,7 +189,6 @@ final class FormViewController: UITableViewController {
             cell.configure(name: NSLocalizedString("time", comment: ""), value: DateFormatter.time.string(from: attestation.date), inputType: .time(DateFormatter.time)) { [weak self] value in
                 let actualDate = DateFormatter.dateFr.string(from: self?.attestation.date ?? Date())
                 self?.attestation.date = DateFormatter.dateTimeFr.date(from: actualDate + " " + value) ?? Date()
-                print("Updated time: " + value + " | attestation date: " + DateFormatter.dateTimeFr.string(from: self?.attestation.date ?? Date() ))
             }
             return cell
 

--- a/AttestationCovid/Shared/DateFormatterUtils.swift
+++ b/AttestationCovid/Shared/DateFormatterUtils.swift
@@ -49,14 +49,28 @@ extension DateFormatter {
     static let dateTimeDigits: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "fr_FR")
-        formatter.dateFormat = "ddMMYYYY'-'HHmm"
+        formatter.dateFormat = "ddMMyyyy'-'HHmm"
         return formatter
     }()
 
     static let readableDateTime: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "fr_FR")
-        formatter.dateFormat = "dd'-'MM'-'YYYY'_'HH'-'mm'-'ss"
+        formatter.dateFormat = "dd'-'MM'-'yyyy'_'HH'-'mm'-'ss"
+        return formatter
+    }()
+    
+    static let dateFr: DateFormatter = {
+           let formatter = DateFormatter()
+           formatter.locale = Locale(identifier: "fr_FR")
+           formatter.dateFormat = "dd/MM/yyyy"
+           return formatter
+       }()
+    
+    static let dateTimeFr: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "fr_FR")
+        formatter.dateFormat = "dd/MM/yyyy HH:mm"
         return formatter
     }()
 }


### PR DESCRIPTION
Fix #2 et #3 
La date et l'heure saisies dans le formulaire sont prises en compte comme date et heure de sortie. Peuvent être dans le futur ou le passé (comme sur le formulaire en ligne).